### PR TITLE
getting post by id returns post's reactions

### DIFF
--- a/models/__init__.py
+++ b/models/__init__.py
@@ -3,3 +3,4 @@ from .comment import Comment
 from .user import User
 from .tag import Tag
 from .category import Category
+from .reaction import Reaction

--- a/models/post.py
+++ b/models/post.py
@@ -11,3 +11,4 @@ class Post():
         self.approved = bool(approved)
         self.tags = None
         self.comments = None
+        self.reactions = None

--- a/models/reaction.py
+++ b/models/reaction.py
@@ -1,0 +1,5 @@
+class Reaction():
+  def __init__(self, id, label, image_url):
+    self.id = id
+    self.label = label
+    self.image_url = image_url

--- a/posts/request.py
+++ b/posts/request.py
@@ -1,3 +1,4 @@
+from models.reaction import Reaction
 import sqlite3
 import json
 from models import Post, Tag, Comment
@@ -161,6 +162,28 @@ def get_post_by_id(id):
                         tag_row['label'])
             post_tags.append(post_tag.__dict__)
         post.tags = post_tags
+
+        db_cursor.execute("""
+        SELECT 
+            pr.id,
+            pr.user_id,
+            pr.reaction_id,
+            pr.post_id,
+            r.label,
+            r.image_url,
+            COUNT(reaction_id) count
+        FROM PostReactions pr
+        JOIN Reactions r ON r.id = pr.reaction_id
+        WHERE pr.post_id = ?
+        GROUP BY reaction_id
+        """, (single_post['id'], ))
+        post_reactions = []
+        dataset = db_cursor.fetchall()
+        for data in dataset:
+            post_reaction = Reaction(data['reaction_id'], data['label'], data['image_url'])
+            post_reaction.count = data['count']
+            post_reactions.append(post_reaction.__dict__)
+        post.reactions = post_reactions
 
         db_cursor.execute("""
         SELECT

--- a/rare-db.session.sql
+++ b/rare-db.session.sql
@@ -98,7 +98,7 @@ CREATE TABLE "Categories" (
 
 INSERT INTO Categories ('label') VALUES ('News');
 INSERT INTO Tags ('label') VALUES ('JavaScript');
-INSERT INTO Reactions ('label', 'image_url') VALUES ('happy', 'https://pngtree.com/so/happy');
+INSERT INTO Reactions ('label', 'image_url') VALUES ('what', 'https://pngtree.com/so/happy');
 INSERT INTO Users ('first_name', 'last_name', 'email', 'bio', 'username', 'password', 'profile_image_url', 'created_on', 'active') VALUES ('phil', 'phan', 'a@b.c', 'it me', 'philphan', 'password', 'https://pngtree.com/so/happy', '2020-01-01', 1);
 INSERT INTO Posts ('user_id', 'category_id', 'title', 'publication_date', 'image_url', 'content', 'approved') VALUES (1, 1, 'new post', '2021-01-01', 'https://pngtree.com/so/happy', 'testing post', 1)
 INSERT INTO comments ('post_id', 'author_id', 'content', 'subject', 'created_on') VALUES (1, 1, 'test', 'test', '2021-01-01')
@@ -109,3 +109,17 @@ SELECT * FROM Comments
 DELETE FROM Comments
 
 DROP TABLE Comments
+
+DROP TABLE PostReactions
+
+INSERT INTO Reactions ('label', 'image_url')
+VALUES ('what', '#');
+INSERT INTO Reactions ('label', 'image_url')
+VALUES ('nice', '#');
+INSERT INTO PostReactions ('user_id', 'reaction_id', 'post_id')
+VALUES (1, 1, 1);
+INSERT INTO PostReactions ('user_id', 'reaction_id', 'post_id')
+VALUES (1, 1, 1);
+INSERT INTO PostReactions ('user_id', 'reaction_id', 'post_id')
+VALUES (1, 2, 1)
+


### PR DESCRIPTION
# Description
Getting post by id will also returns the reactions on that post as well as the count for each reaction.
## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Testing Instructions
Add reactions and post_reactions to your SQL tables
```
INSERT INTO Reactions ('label', 'image_url')
VALUES ('what', '#');
INSERT INTO Reactions ('label', 'image_url')
VALUES ('nice', '#');
INSERT INTO PostReactions ('user_id', 'reaction_id', 'post_id')
VALUES (1, 1, 1);
INSERT INTO PostReactions ('user_id', 'reaction_id', 'post_id')
VALUES (1, 1, 1);
INSERT INTO PostReactions ('user_id', 'reaction_id', 'post_id')
VALUES (1, 2, 1)
```
Make a GET request for the post with id = 1
```
http://localhost:8088/posts/1
```
Make sure that the returned post has a reactions property with the count on each reaction.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings or errors
- [x] I have added test instructions that prove my fix is effective or that my feature works
