### PR TITLE
Kk prevent admin loss by change in user type

### DIFF
--- a/request_handler.py
+++ b/request_handler.py
@@ -166,13 +166,15 @@ class HandleRequests(BaseHTTPRequestHandler):
         elif resource == "posts":
             success = update_post(id, post_body)
         # rest of the elif's
+        self.wfile.write("".encode())
 
-        if success:
+        if success == True:
             self._set_headers(204)
+        elif success == False:
+            self._set_headers(404)
         else:
             self._set_headers(404)
-
-        self.wfile.write("".encode())
+            self.wfile.write(success.encode())
 
     def do_PATCH(self):
         content_len = int(self.headers.get('content-length', 0))

--- a/users/request.py
+++ b/users/request.py
@@ -181,18 +181,31 @@ def change_user_type(user_body):
         conn.row_factory = sqlite3.Row
         db_cursor = conn.cursor()
 
-        user_to_change = get_user_by_id(int(user_body["id"]))
+        rows_affected = None
 
-        if user_to_change["is_admin"] == True:
-            admin_users = get_users_by_profile_type("True")
+        user_to_change = json.loads(get_user_by_id(int(user_body["id"])))
 
-        db_cursor.execute(""" 
-        UPDATE Users
-        SET is_admin = NOT is_admin
-        WHERE id = ?
-        """, (int(user_body["id"]),))
+        if user_to_change["isAdmin"] == True:
+            admin_users = json.loads(get_users_by_profile_type("True"))
+            if len(admin_users) == 1:
+                return "Error: Must have at least one admin user at all times"
 
-        rows_affected = db_cursor.rowcount
+            else:
+                db_cursor.execute(""" 
+                UPDATE Users
+                SET is_admin = NOT is_admin
+                WHERE id = ?
+                """, (int(user_body["id"]),))
+
+                rows_affected = db_cursor.rowcount
+        else:
+            db_cursor.execute(""" 
+            UPDATE Users
+            SET is_admin = NOT is_admin
+            WHERE id = ?
+            """, (int(user_body["id"]),))
+
+            rows_affected = db_cursor.rowcount
 
         if rows_affected > 0:
             return True

--- a/users/request.py
+++ b/users/request.py
@@ -181,6 +181,11 @@ def change_user_type(user_body):
         conn.row_factory = sqlite3.Row
         db_cursor = conn.cursor()
 
+        user_to_change = get_user_by_id(int(user_body["id"]))
+
+        if user_to_change["is_admin"] == True:
+            admin_users = get_users_by_profile_type("True")
+
         db_cursor.execute(""" 
         UPDATE Users
         SET is_admin = NOT is_admin


### PR DESCRIPTION
# Description
     Admin will only be deactivated if at least one other user is an admin; there is no constraint on promoting users to admin

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Testing Instructions
Have at least 2 admin users
```
PUT http://localhost:8088/user_type

{
    "id": "ADMIN-USER-ID"
}
```
User should no longer be an admin

Repeat the process again and you should receive an error message stating that there must always be at least one admin user

# Checklist:

- [ ] My code follows the style guidelines of this project
- [X ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [X ] My changes generate no new warnings or errors
- [X ] I have added test instructions that prove my fix is effective or that my feature works
